### PR TITLE
Don't try to login with email when you have a security token

### DIFF
--- a/index.js
+++ b/index.js
@@ -293,20 +293,23 @@ AugustPlatform.prototype.identify = function (accessory, paired, callback) {
 AugustPlatform.prototype.login = function (callback) {
   var self = this;
 
-  // Log in
-  var authenticate = this.augustApi.authenticate('email:' + this.email, this.password);
-  authenticate.then(function (result) {
-    self.userId = result.body.userId;
-    self.platformLog("Logged in with ID " + self.userId);
-    self.securityToken = result.response.headers['x-august-access-token'];
+  if (self.securityToken) {
     self.postLogin(callback);
+  } else {
+    // Log in
+    var authenticate = this.augustApi.authenticate('email:' + this.email, this.password);
+    authenticate.then(function (result) {
+      self.userId = result.body.userId;
+      self.platformLog("Logged in with ID " + self.userId);
+      self.securityToken = result.response.headers['x-august-access-token'];
+      self.postLogin(callback);
 
-  }, function (error) {
-    self.platformLog(error);
-    callback(error, null);
+    }, function (error) {
+      self.platformLog(error);
+      callback(error, null);
 
-  });
-
+    });
+  }
 }
 
 AugustPlatform.prototype.postLogin = function (accessory, paired, getlocks, callback) {


### PR DESCRIPTION
Once you have a token, it is still trying to login using email/password which will of course fail.  Update to short circuit login and immediately go to postLogin with the security token.